### PR TITLE
Update theme color to LineageOS teal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This repository hosts a [Material 3](https://m3.material.io/) theme for the [Obsidian](https://obsidian.md/) note-taking tool.
 
+The primary accent color has been updated to match **LineageOS teal** (`#009688`).
+Rebuild the theme via `npm run build` after cloning to generate `theme.css`.
+
 *Due to limitations, this theme does not support dynamic color on Android.* Therefore, the color schemes of this theme were generated based on Obsidian's brand colors.
 
 ## Manual installation

--- a/src/tokens/_colors.scss
+++ b/src/tokens/_colors.scss
@@ -199,8 +199,9 @@ $_default-light: (
 }
 
 :root {
-  --md-key-colors-primary: rgb(134, 88, 255);
-  --md-source-seed: rgb(134, 88, 255);
+  /* Primary accent color changed to LineageOS teal */
+  --md-key-colors-primary: rgb(0, 150, 136);
+  --md-source-seed: rgb(0, 150, 136);
   --md-extended-green-seed: rgb(8, 185, 78);
   --md-extended-green-value: rgb(0, 183, 126);
   --md-extended-red-seed: rgb(233, 49, 71);

--- a/utils/generateReferencePalette.ts
+++ b/utils/generateReferencePalette.ts
@@ -6,7 +6,8 @@ import {
 
 import json2scss from 'json2scss-map';
 
-const OBSIDIAN_PURPLE_ARGB = 0xff8758ff;
+// Seed color changed to LineageOS teal
+const OBSIDIAN_PURPLE_ARGB = 0xff009688;
 const PALETTE_SUPPORTED_TOKENS = [
   'black',
   'error0',


### PR DESCRIPTION
## Summary
- switch material key color to LineageOS teal
- mention new color and rebuild step in README

## Testing
- `npm run build` *(fails: sass not found)*

------
https://chatgpt.com/codex/tasks/task_e_686177b65588832e80c263f28652d0ce